### PR TITLE
Require fully supported Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
-sudo: false
+sudo: true
 cache: pip
-python: '3.6'
+python: '3.7'
+dist: xenial
 env:
   global:
     - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,12 @@ env:
     - TOXENV=docs
 matrix:
   include:
-    - python: '3.6'
+    - python: '3.7'
       env:
-        - TOXENV=3.6-cover,report,codecov
-    - python: '3.6'
+        - TOXENV=3.7-cover,report,codecov
+    - python: '3.7'
       env:
-        - TOXENV=3.6-nocov
+        - TOXENV=3.7-nocov
 before_install:
   - python --version
   - uname -a

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,9 @@ environment:
     WITH_COMPILER: 'cmd /E:ON /V:ON /C .\ci\appveyor-with-compiler.cmd'
   matrix:
     - TOXENV: check
-      TOXPYTHON: C:\Python36\python.exe
-      PYTHON_HOME: C:\Python36
-      PYTHON_VERSION: '3.6'
+      TOXPYTHON: C:\Python37\python.exe
+      PYTHON_HOME: C:\Python37
+      PYTHON_VERSION: '3.7'
       PYTHON_ARCH: '32'
     - TOXENV: '3.7-cover,report,codecov'
       TOXPYTHON: C:\Python37\python.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,28 +11,28 @@ environment:
       PYTHON_HOME: C:\Python36
       PYTHON_VERSION: '3.6'
       PYTHON_ARCH: '32'
-    - TOXENV: '3.6-cover,report,codecov'
-      TOXPYTHON: C:\Python36\python.exe
-      PYTHON_HOME: C:\Python36
-      PYTHON_VERSION: '3.6'
+    - TOXENV: '3.7-cover,report,codecov'
+      TOXPYTHON: C:\Python37\python.exe
+      PYTHON_HOME: C:\Python37
+      PYTHON_VERSION: '3.7'
       PYTHON_ARCH: '32'
-    - TOXENV: '3.6-cover,report,codecov'
-      TOXPYTHON: C:\Python36-x64\python.exe
+    - TOXENV: '3.7-cover,report,codecov'
+      TOXPYTHON: C:\Python37-x64\python.exe
       WINDOWS_SDK_VERSION: v7.1
-      PYTHON_HOME: C:\Python36-x64
-      PYTHON_VERSION: '3.6'
+      PYTHON_HOME: C:\Python37-x64
+      PYTHON_VERSION: '3.7'
       PYTHON_ARCH: '64'
 
-    - TOXENV: '3.6-nocov'
-      TOXPYTHON: C:\Python36\python.exe
-      PYTHON_HOME: C:\Python36
-      PYTHON_VERSION: '3.6'
+    - TOXENV: '3.7-nocov'
+      TOXPYTHON: C:\Python37\python.exe
+      PYTHON_HOME: C:\Python37
+      PYTHON_VERSION: '3.7'
       PYTHON_ARCH: '32'
-    - TOXENV: '3.6-nocov'
-      TOXPYTHON: C:\Python36-x64\python.exe
+    - TOXENV: '3.7-nocov'
+      TOXPYTHON: C:\Python37-x64\python.exe
       WINDOWS_SDK_VERSION: v7.1
-      PYTHON_HOME: C:\Python36-x64
-      PYTHON_VERSION: '3.6'
+      PYTHON_HOME: C:\Python37-x64
+      PYTHON_VERSION: '3.7'
       PYTHON_ARCH: '64'
 
 init:

--- a/ci/templates/.travis.yml
+++ b/ci/templates/.travis.yml
@@ -1,7 +1,8 @@
 language: python
-sudo: false
+sudo: true
 cache: pip
-python: '3.6'
+python: '3.7'
+dist: xenial
 env:
   global:
     - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so

--- a/ci/templates/appveyor.yml
+++ b/ci/templates/appveyor.yml
@@ -7,9 +7,9 @@ environment:
     WITH_COMPILER: 'cmd /E:ON /V:ON /C .\ci\appveyor-with-compiler.cmd'
   matrix:
     - TOXENV: check
-      TOXPYTHON: C:\Python36\python.exe
-      PYTHON_HOME: C:\Python36
-      PYTHON_VERSION: '3.6'
+      TOXPYTHON: C:\Python37\python.exe
+      PYTHON_HOME: C:\Python37
+      PYTHON_VERSION: '3.7'
       PYTHON_ARCH: '32'
 {% for env, config in tox_environments|dictsort %}{{ '' }}{% if config.python.startswith('python') %}
     - TOXENV: '{{ env }}{% if config.cover %},report,codecov{% endif %}'

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,8 +61,7 @@ skip = migrations
 #  - can use as many you want
 
 python_versions =
-    3.6
-#    3.7
+    3.7
 
 dependencies =
 

--- a/setup.py
+++ b/setup.py
@@ -69,4 +69,5 @@ setup(
         #   'rst': ['docutils>=0.11'],
         #   ':python_version=="2.6"': ['argparse'],
     },
+    python_requires='>=3.6.6, <4',
 )

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         # uncomment if you test on these interpreters:
@@ -69,5 +69,5 @@ setup(
         #   'rst': ['docutils>=0.11'],
         #   ':python_version=="2.6"': ['argparse'],
     },
-    python_requires='>=3.6.6, <4',
+    python_requires='>=3.7',
 )

--- a/src/structured_data/__init__.py
+++ b/src/structured_data/__init__.py
@@ -325,19 +325,6 @@ def _make_constructor(_cls, name, length, subclasses, subclass_order):
     subclass_order.append(Constructor)
 
 
-def _allow_subclassing_generic(cls):
-    return hasattr(
-        typing, 'GenericMeta') and isinstance(cls, typing.GenericMeta)
-
-
-_SUBCLASS_CHECKS = [_allow_subclassing_generic]
-
-
-def add_subclass_check(predicate):
-    """Allow additional subclasses."""
-    _SUBCLASS_CHECKS.append(predicate)
-
-
 def _process_class(_cls, _repr, eq, order):
     if order and not eq:
         raise ValueError('eq must be true if order is true')
@@ -358,17 +345,9 @@ def _process_class(_cls, _repr, eq, order):
         _make_constructor(
             _cls, name, length, subclasses, subclass_order)
 
-    if any(predicate(_cls) for predicate in _SUBCLASS_CHECKS):
-        @classmethod
-        def __init_subclass__(cls, **kwargs):
-            if issubclass(cls, tuple(subclasses)):
-                raise TypeError
-            # Allow it to go through otherwise, because Generic.
-            return super(_cls, cls).__init_subclass__(**kwargs)
-    else:
-        @classmethod
-        def __init_subclass__(cls, **kwargs):
-            raise TypeError
+    @classmethod
+    def __init_subclass__(cls, **kwargs):
+        raise TypeError
 
     _cls.__init_subclass__ = __init_subclass__
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
     clean,
     check,
-    3.6-cover,
-    3.6-nocov,
+    3.7-cover,
+    3.7-nocov,
     report,
     docs
 
@@ -112,8 +112,8 @@ skip_install = true
 usedevelop = false
 deps = coverage
 
-[testenv:3.6-cover]
-basepython = {env:TOXPYTHON:python3.6}
+[testenv:3.7-cover]
+basepython = {env:TOXPYTHON:python3.7}
 setenv =
     {[testenv]setenv}
 usedevelop = true
@@ -123,8 +123,8 @@ deps =
     {[testenv]deps}
     pytest_divide_and_cover
 
-[testenv:3.6-nocov]
-basepython = {env:TOXPYTHON:python3.6}
+[testenv:3.7-nocov]
+basepython = {env:TOXPYTHON:python3.7}
 
 
 


### PR DESCRIPTION
Routing enum constructors through Generic is broken through 3.6.5, and from inspecting the source code, should work in all subsequent versions.